### PR TITLE
Ci/jenkins email notify

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 DATABASE_URL="postgres://user:password@db:5432/mydb"
 NEXTAUTH_URL=http://localhost:3000
 NEXTAUTH_SECRET=uJVL6Z+u6Q6fBYW/LiYlxG+TQTeXC4QGohLjRzXFDec=
+
+EMAIL_SENDER=
+EMAIL_PASS=
+
+EMAIL_LIST=

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -93,6 +93,9 @@ pipeline {
         }
         failure {
             echo 'Tests failed. Please check the test reports.'
+            mail to: "${EMAIL_LIST}",
+             subject: "Build Failed: ${env.JOB_NAME} #${env.BUILD_NUMBER}",
+             body: "The build has failed. Check logs."
         }
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,9 @@ services:
       - JAVA_OPTS=-Djenkins.install.runSetupWizard=false
       - CASC_JENKINS_CONFIG=/var/jenkins_home/casc.yaml
       - NEXTAUTH_SECRET=${NEXTAUTH_SECRET}
+      - EMAIL_LIST=${EMAIL_LIST}
+      - EMAIL_SENDER=${EMAIL_SENDER}
+      - EMAIL_PASS=${EMAIL_PASS}
     restart: unless-stopped
     depends_on:
       - sonarqube

--- a/docker/Dockerfile.jenkins
+++ b/docker/Dockerfile.jenkins
@@ -28,6 +28,7 @@ RUN jenkins-plugin-cli --plugins \
     htmlpublisher:latest \
     job-dsl:latest \
     git-client:latest \
-    sonar:latest
+    sonar:latest \
+    mailer:latest
 
 ENV JAVA_OPTS="-Djenkins.install.runSetupWizard=false"

--- a/jenkins-casc.yaml
+++ b/jenkins-casc.yaml
@@ -47,7 +47,42 @@ jobs:
         }
       }
 
+  - script: >
+      pipelineJob('email-test') {
+        definition {
+          cps {
+            script("""
+              pipeline {
+                agent any
+                stages {
+                  stage('Send Email') {
+                    steps {
+                      echo "Sending test mail..."
+                      echo "${EMAIL_LIST}"
+                      mail to: "${EMAIL_LIST}",
+                           subject: "Teste de Email - Jenkins",
+                           body: "Este é um e-mail de teste enviado pelo Jenkins via JCasC."
+                    }
+                  }
+                }
+              }
+            """)
+            sandbox()
+          }
+        }
+      }
+
 unclassified:
+  mailer:
+    smtpHost: 'smtp.gmail.com'
+    smtpPort: '587'
+    useSsl: false
+    useTls: true
+    replyToAddress: '${EMAIL_SENDER}'
+    authentication:
+      username: '${EMAIL_SENDER}'
+      password: '${EMAIL_PASS}'
+
   globalLibraries:
     libraries: []
 


### PR DESCRIPTION
Adicionado notificação por email quando falha o pipeline falha.

Como testar localmente:
- Configure o .env
- Edite o `jenkins-casc.yaml`
```yaml
jobs:
  - script: >
      pipelineJob('projeto-c14-pipeline') {
        definition {
          cpsScm {
            scm {
              git {
                remote {
                  url('https://github.com/C14-2025/food-pet.git')
                }
                branches('*/master')
                extensions { }
              }
            }
            scriptPath('Jenkinsfile')
          }
        }
      }
```
para
```yaml
jobs:
  - script: >
      pipelineJob('projeto-c14-pipeline') {
        definition {
          cpsScm {
            scm {
              git {
                remote {
                  url('https://github.com/C14-2025/food-pet.git')
                }
                branches('*/ci/jenkins-email-notify')
                extensions { }
              }
            }
            scriptPath('Jenkinsfile')
          }
        }
      }
```
- Execute a pipeline sem a aplicação ativa (para forçar um erro)